### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
 
   zookeeper:
     container_name: zookeeper
-    image: bitnami/zookeeper:3.9.1
+    image: soldevelo/zookeeper:3.9.5
     # to survive the container restart
     tmpfs: "/zktmp"
     environment:
@@ -27,7 +27,7 @@ services:
 
   kafka:
     container_name: kafka
-    image: 'bitnami/kafka:4.0.0'
+    image: 'soldevelo/kafka:4.0.0'
     ports:
       - '9092:9092'				# for host internal connection
       - '9094:9094'				# for host external connection 


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/zookeeper:3.9.1` → [`soldevelo/zookeeper:3.9.5`](https://hub.docker.com/r/soldevelo/zookeeper)
- `bitnami/kafka:4.0.0` → [`soldevelo/kafka:4.0.0`](https://hub.docker.com/r/soldevelo/kafka)